### PR TITLE
feat/encode sequence as a vector of chars

### DIFF
--- a/src/triplex.hpp
+++ b/src/triplex.hpp
@@ -516,15 +516,15 @@ inline void parse_segments(TGraph& parser,
 }
 
 template <typename TString, typename TChar>
-inline std::vector<std::vector<bool>> encode_sequence(TString& motif,
+inline std::vector<std::vector<char>> encode_sequence(TString& motif,
                                                       TChar filter_char,
                                                       TChar interrupt_char,
-                                                      std::vector<std::vector<bool>>& block_runs,
+                                                      std::vector<std::vector<char>>& block_runs,
                                                       unsigned int min_block_run)
 {
     typedef typename Iterator<TString, Standard>::Type TIter;
 
-    std::vector<std::vector<bool>> encoded_seq(3, std::vector<bool>(length(motif), false));
+    std::vector<std::vector<char>> encoded_seq(3, std::vector<char>(length(motif), 0));
 
     unsigned int counter = 0;
     unsigned int run_counter = 0;
@@ -817,9 +817,9 @@ inline unsigned int filter_with_guanine_and_error_rate(TMotifSet& motif_set,
 
     auto motif_length = length(motif);
 
-    std::vector<std::vector<bool>> encoded_seq;
-    std::vector<std::vector<bool>> block_runs(motif_length - opts.min_block_run + 1,
-                                              std::vector<bool>(motif_length + 1, false));
+    std::vector<std::vector<char>> encoded_seq;
+    std::vector<std::vector<char>> block_runs(motif_length - opts.min_block_run + 1,
+                                              std::vector<char>(motif_length + 1, 0));
     if (opts.min_guanine_rate <= 0.0) {
         TFilter filter_sequence(motif);
         filter_char = filter_char == 'G' ? 'R' : 'Y';


### PR DESCRIPTION
**Changes proposed:**

- Encode the sequences as char vectors to improve access times.

**Discussion:**

- "The reason `std::vector<bool>` is nonconforming is that it pulls tricks under the covers in an attempt to optimize for space: Instead of storing a full char or int for every bool (taking up at least 8 times the space, on platforms with 8-bit chars), it packs the bools and stores them as individual bits (inside, say, chars) in its internal representation. One consequence of this is that it can't just return a normal bool& from its operator[] or its dereferenced iterators; instead, it has to play games with a helper "proxy" class that is bool-like but is definitely not a bool. Unfortunately, that also means that access into a `vector<bool>` is slower, because we have to deal with proxies instead of direct pointers and references."
- "If you care more about speed than you do about size, you shouldn't use `std::vector<bool>`. Instead, you should hack around this optimization by using a `std::vector<char>` or the like instead, which is unfortunate but still the best you can do."

**Benchmark:**
| TFO Dataset | TTS Dataset | `std::vector<bool>` | `std::vector<char>` |
|:-----------:|:-----------:|:-----------------:|:-----------------:|
|  Lepi ncRNA |   Lepi DNA  |           19m 10s |      18m 46s      |
| Ursus ncRNA |  Ursus DNA  |     1h 36m 04s    |   1h 33m 14s   |
| Anser ncRNA | Anser DNA   | 4h 19m 20s        |   4h 6m 26s  |

**References:**
[1] http://www.gotw.ca/gotw/050.htm
[2] https://stackoverflow.com/questions/4156538/how-can-stdbitset-be-faster-than-stdvectorbool