### PR TITLE
fix/remove deprecation warnings gcc12

### DIFF
--- a/include/seqan/align/gap_anchor.h
+++ b/include/seqan/align/gap_anchor.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_INCLUDE_SEQAN_ALIGN_GAP_ANCHOR_H_
 #define SEQAN_INCLUDE_SEQAN_ALIGN_GAP_ANCHOR_H_
 
+#include <functional>
+
 namespace seqan {
 
 // ============================================================================
@@ -221,7 +223,7 @@ struct _LessGapAnchor;
 
 template <typename TGapAnchor>
 struct _LessGapAnchor<TGapAnchor, SortSeqPos> :
-    public std::binary_function<TGapAnchor, TGapAnchor, bool>
+    std::function<bool(TGapAnchor,TGapAnchor)>
 {
     inline bool
     operator() (TGapAnchor const& a1, TGapAnchor const& a2) const {
@@ -231,7 +233,7 @@ struct _LessGapAnchor<TGapAnchor, SortSeqPos> :
 
 template <typename TGapAnchor>
 struct _LessGapAnchor<TGapAnchor, SortGapPos> :
-    public std::binary_function<TGapAnchor, TGapAnchor, bool>
+    std::function<bool(TGapAnchor,TGapAnchor)>
 {
     inline bool
     operator() (TGapAnchor const& a1, TGapAnchor const& a2) const {

--- a/include/seqan/file/string_external.h
+++ b/include/seqan/file/string_external.h
@@ -37,6 +37,8 @@
 #ifndef SEQAN_HEADER_STRING_EXTERNAL_H
 #define SEQAN_HEADER_STRING_EXTERNAL_H
 
+#include <functional>
+
 /* IOREV
  * _nottested_
  * _doc_

--- a/include/seqan/file/string_external.h
+++ b/include/seqan/file/string_external.h
@@ -1335,7 +1335,7 @@ namespace seqan
             pf.pageNo = -1;                                 // cut back link
         }
 
-        struct testIODone : public std::unary_function<TPageFrame&,bool>
+        struct testIODone : std::function<bool(TPageFrame&)>
         {
             String &me;
             testIODone(String &_me): me(_me) {}

--- a/include/seqan/graph_algorithms/graph_algorithm_heap_tree.h
+++ b/include/seqan/graph_algorithms/graph_algorithm_heap_tree.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_GRAPH_ALGORITHM_HEAP_TREE_H
 #define SEQAN_HEADER_GRAPH_ALGORITHM_HEAP_TREE_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -321,8 +323,7 @@ heapSort(TITBegin itBeg,
 //////////////////////////////////////////////////////////////////////////////
 
 template<typename TKey, typename TValue, typename TPredicate>
-struct LessPairI2WithFunctor :
-    public std::unary_function<Pair<TKey, TValue>, bool>
+struct LessPairI2WithFunctor : std::function<bool(Pair<TKey, TValue>,Pair<TKey, TValue>)>
 {
     inline bool
     operator() (Pair<TKey, TValue> const& a1, Pair<TKey, TValue> const& a2) {

--- a/include/seqan/graph_algorithms/kruskal.h
+++ b/include/seqan/graph_algorithms/kruskal.h
@@ -37,6 +37,8 @@
 #ifndef INCLUDE_SEQAN_GRAPH_ALGORITHMS_KRUSKAL_H_
 #define INCLUDE_SEQAN_GRAPH_ALGORITHMS_KRUSKAL_H_
 
+#include <functional>
+
 namespace seqan {
 
 // ============================================================================
@@ -60,7 +62,7 @@ namespace seqan {
 // ----------------------------------------------------------------------------
 
 template <typename TWeight, typename TPair>
-struct LessPairI1_ : public std::unary_function<Pair<TWeight, TPair>, bool>
+struct LessPairI1_ : std::function<bool(Pair<TWeight, TPair>,Pair<TWeight, TPair>)>
 {
     bool operator() (Pair<TWeight, TPair> const & a1,
                      Pair<TWeight, TPair> const & a2) const

--- a/include/seqan/index/index_base.h
+++ b/include/seqan/index/index_base.h
@@ -36,6 +36,8 @@
 #ifndef SEQAN_HEADER_INDEX_BASE_H
 #define SEQAN_HEADER_INDEX_BASE_H
 
+#include <functional>
+
 //#define SEQAN_TEST_INDEX
 
 namespace seqan
@@ -337,7 +339,7 @@ template <
     };
 
     // less function to search in sorted list for fibre id
-    struct FibreLess: public std::binary_function<FibreRecord, unsigned, bool>
+    struct FibreLess: std::function<bool(FibreRecord,unsigned)>
     {    // functor for operator>
         inline bool operator()(FibreRecord const & _Left, unsigned const Right_) const
         {    // apply operator> to operands
@@ -643,7 +645,7 @@ template <
 // globalize functor
 
     template <typename InType, typename TLimitsString, typename Result = typename Value<TLimitsString>::Type>
-    struct FunctorGlobalize : public std::unary_function<InType,Result>
+    struct FunctorGlobalize : std::function<Result(InType)>
     {
         TLimitsString const * limits;
 
@@ -657,7 +659,7 @@ template <
     };
 
     template <typename InType, typename Result>
-    struct FunctorGlobalize<InType, Nothing, Result> : public std::unary_function<InType,InType>
+    struct FunctorGlobalize<InType, Nothing, Result> : std::function<InType(InType)>
     {
         FunctorGlobalize() {}
         FunctorGlobalize(Nothing const &) {}

--- a/include/seqan/index/index_bwt.h
+++ b/include/seqan/index/index_bwt.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_INDEX_BWT_H
 #define SEQAN_HEADER_INDEX_BWT_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -141,7 +143,7 @@ namespace seqan
     };
 
     template <typename InType, typename TLimitsString, typename Result = typename Value<TLimitsString>::Type>
-    struct _filterGlobalizer : public std::unary_function<InType,Result> {
+    struct _filterGlobalizer : std::function<Result(InType)> {
         TLimitsString const &limits;
         _filterGlobalizer(TLimitsString const &_limits) : limits(_limits) {}
         inline Result operator()(const InType& x) const

--- a/include/seqan/index/index_lcp.h
+++ b/include/seqan/index/index_lcp.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_INDEX_LCP_H
 #define SEQAN_HEADER_INDEX_LCP_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -56,7 +58,7 @@ namespace seqan
     };
 
     template <typename InType, typename Result = typename Value< typename Value<InType, 2>::Type>::Type>
-    struct _mapInverse : public std::unary_function<InType,Result> {
+    struct _mapInverse : std::function<Result(InType)> {
         inline Result operator()(const InType& x) const
         { return x.i2[0]; }
     };
@@ -161,7 +163,7 @@ namespace seqan
     };
 
     template <typename InType, typename TLimitsString, typename Result = typename Value<TLimitsString>::Type>
-    struct _mapInverseMulti : public std::unary_function<InType,Result> {
+    struct _mapInverseMulti : std::function<Result(InType)> {
         TLimitsString const &limits;
         _mapInverseMulti(TLimitsString const &_limits) : limits(_limits) {}
         inline Result operator()(const InType& x) const

--- a/include/seqan/index/index_qgram.h
+++ b/include/seqan/index/index_qgram.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_INDEX_QGRAM_H
 #define SEQAN_HEADER_INDEX_QGRAM_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -663,7 +665,7 @@ inline int64_t _fullDir2Length(TIndex const &index)
 // compare two q-grams of a given text (q-grams can be smaller than q)
 template < typename TSAValue, typename TText >
 struct QGramLess_ :
-public std::binary_function < TSAValue, TSAValue, bool >
+std::function<bool(TSAValue, TSAValue)>
 {
     typedef typename Iterator<TText, Standard>::Type TIter;
     TIter _begin, _end;
@@ -711,7 +713,7 @@ public std::binary_function < TSAValue, TSAValue, bool >
 
 template < typename TSAValue, typename TString, typename TSpec >
 struct QGramLess_<TSAValue, StringSet<TString, TSpec> const> :
-public std::binary_function < TSAValue, TSAValue, bool >
+std::function<bool(TSAValue, TSAValue)>
 {
     typedef typename Iterator<TString const, Standard>::Type TIter;
     typedef typename Size<TString>::Type                     TSize;
@@ -779,7 +781,7 @@ QGramLess_<TSAValue, TText>
 
 template < typename TSAValue, typename TString, typename TSpec >
 struct QGramLessOffset_<TSAValue, StringSet<TString, TSpec> const> :
-public std::binary_function < TSAValue, TSAValue, bool >
+std::function<bool(TSAValue, TSAValue)>
 {
     typedef typename Iterator<TString const, Standard>::Type TIter;
     typedef typename Size<TString>::Type                     TSize;
@@ -848,7 +850,7 @@ public std::binary_function < TSAValue, TSAValue, bool >
 // compare two q-grams of a given text (no check for q-grams smaller than q)
 template < typename TSAValue, typename TText >
 struct QGramLessNoCheck_ :
-public std::binary_function < TSAValue, TSAValue, bool >
+std::function<bool(TSAValue, TSAValue)>
 {
     typedef typename Iterator<TText, Standard>::Type TIter;
     TIter _begin;
@@ -882,7 +884,7 @@ public std::binary_function < TSAValue, TSAValue, bool >
 
 template < typename TSAValue, typename TString, typename TSpec >
 struct QGramLessNoCheck_<TSAValue, StringSet<TString, TSpec> const> :
-public std::binary_function < TSAValue, TSAValue, bool >
+std::function<bool(TSAValue, TSAValue)>
 {
     typedef typename Iterator<TString, Standard>::Type  TIter;
     typedef StringSet<TString, TSpec>                   TStringSet;
@@ -930,7 +932,7 @@ struct QGramLessNoCheckOffset_: QGramLessNoCheck_<TSAValue, TText>
 
 template < typename TSAValue, typename TString, typename TSpec >
 struct QGramLessNoCheckOffset_<TSAValue, StringSet<TString, TSpec> const> :
-public std::binary_function < TSAValue, TSAValue, bool >
+std::function<bool(TSAValue, TSAValue)>
 {
     typedef typename Iterator<TString, Standard>::Type TIter;
     StringSet<TString, TSpec> const &_stringSet;
@@ -1811,7 +1813,7 @@ void createCountsArray(
 // *** COMPARATORS & MAPS ***
 
 template <typename InType, typename Result = int>
-struct _qgramComp : public std::binary_function<InType,InType,Result> {
+struct _qgramComp : std::function<Result(InType,InType)> {
     inline Result operator()(InType const &a, InType const &b) const
     {
         typedef typename Value<InType, 2>::Type TQGram;
@@ -1830,10 +1832,8 @@ struct _qgramComp : public std::binary_function<InType,InType,Result> {
 // optimized for bitvectors
 template <typename T1, typename TValue, unsigned _size, typename Result>
 struct _qgramComp< Pair<T1, Tuple<TValue, _size, BitPacked<> >, Pack >, Result > :
-public std::binary_function<
-Pair<T1, Tuple<TValue, _size, BitPacked<> >, Pack >,
-Pair<T1, Tuple<TValue, _size, BitPacked<> >, Pack >,
-Result> {
+std::function<Result(Pair<T1, Tuple<TValue, _size, BitPacked<> >, Pack >,Pair<T1, Tuple<TValue, _size, BitPacked<> >, Pack >)>
+{
     inline Result operator()(
                              const Pair<T1, Tuple<TValue, _size, BitPacked<> >, Pack > &a,
                              const Pair<T1, Tuple<TValue, _size, BitPacked<> >, Pack > &b) const

--- a/include/seqan/index/index_sa_qsort.h
+++ b/include/seqan/index/index_sa_qsort.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_INDEX_SA_QSORT_H
 #define SEQAN_HEADER_INDEX_SA_QSORT_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -43,7 +45,7 @@ namespace seqan
     // compare two suffices of a given text
     template < typename TSAValue, typename TText >
     struct SuffixLess_ :
-        public std::binary_function < TSAValue, TSAValue, bool >
+        std::function<bool(TSAValue, TSAValue)>
     {
         typedef typename Iterator<TText const, Standard>::Type TIter;
         TIter _begin, _end;
@@ -82,7 +84,7 @@ namespace seqan
     // compare two suffices of a given text
     template < typename TSAValue, typename TString, typename TSetSpec >
     struct SuffixLess_<TSAValue, StringSet<TString, TSetSpec> const > :
-        public std::binary_function < TSAValue, TSAValue, bool >
+        std::function<bool(TSAValue, TSAValue)>
     {
         typedef StringSet<TString, TSetSpec> const TText;
 

--- a/include/seqan/index/index_shims.h
+++ b/include/seqan/index/index_shims.h
@@ -36,6 +36,8 @@
 #ifndef SEQAN_HEADER_INDEX_SHIMS_H
 #define SEQAN_HEADER_INDEX_SHIMS_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -553,7 +555,7 @@ namespace seqan
 
     template <typename T1, typename T2, typename TPack>
     struct SAValueLess_< Pair<T1,T2,TPack> >:
-        public std::binary_function< Pair<T1,T2,TPack>, Pair<T1,T2,TPack>, bool>
+        std::function<bool(Pair<T1,T2,TPack>,Pair<T1,T2,TPack>)>
     {
         inline bool operator()(Pair<T1,T2,TPack> const &a, Pair<T1,T2,TPack> const &b) const {
             return    (getValueI1(a) < getValueI1(b)) ||

--- a/include/seqan/index/index_skew3.h
+++ b/include/seqan/index/index_skew3.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_INDEX_SKEW3_H
 #define SEQAN_HEADER_INDEX_SKEW3_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -62,7 +64,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = int>
     struct _skew3NComp :
-        public std::binary_function<TValue, TValue, TResult>
+        std::function<TResult(TValue,TValue)>
     {
         inline TResult operator() (const TValue &a, const TValue &b) const
         {
@@ -95,7 +97,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = typename Value<TValue, 1>::Type>
     struct _skew3NMapLinear :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
         TResult BN;
 
@@ -109,7 +111,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = typename Value<TValue, 1>::Type>
     struct _skew3NMapSliced :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
         TResult BN, BN2;
 
@@ -124,7 +126,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = TValue>
     struct _skew3UnslicerFunc :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
         TResult o1, o2, n2;
 
@@ -141,7 +143,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = typename Value<typename Value<TValue, 2>::Type>::Type>
     struct _skew3NMapExtended :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
         inline TResult operator() (const TValue & x) const
         {
@@ -151,7 +153,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = int>
     struct _skew3ExtendComp :
-        public std::binary_function<TValue, TValue, TResult>
+        std::function<TResult(TValue,TValue)>
     {
         inline TResult operator() (const TValue &a, const TValue &b) const
         {

--- a/include/seqan/index/index_skew7.h
+++ b/include/seqan/index/index_skew7.h
@@ -32,6 +32,8 @@
 // Author: David Weese <david.weese@fu-berlin.de>
 // ==========================================================================
 
+#include <functional>
+
 #ifndef SEQAN_HEADER_INDEX_SKEW7_H
 #define SEQAN_HEADER_INDEX_SKEW7_H
 
@@ -62,7 +64,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = int>
     struct _skew7NComp :
-        public std::binary_function<TValue, TValue, TResult>
+        std::function<TResult(TValue,TValue)>
     {
         inline TResult operator() (const TValue &a, const TValue &b) const
         {
@@ -96,10 +98,7 @@ namespace seqan
     // optimized for bitvectors
     template <typename T1, typename TValue, typename TResult>
     struct _skew7NComp< Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >, TResult > :
-        public std::binary_function<
-            Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >,
-            Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >,
-            TResult>
+        std::function<TResult(Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >,Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >)>
     {
         inline TResult operator() (
             const Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack > &a,
@@ -115,7 +114,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = typename Value<TValue, 1>::Type>
     struct _skew7NMapLinear :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
         TResult BN4, BN;
 
@@ -129,7 +128,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = typename Value<TValue, 1>::Type>
     struct _skew7NMapSliced :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
         TResult off[5];
 
@@ -151,7 +150,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = TValue>
     struct _skew7UnslicerFunc :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
         TResult o1, o2, o4, n4, n24;
 
@@ -172,7 +171,7 @@ namespace seqan
 
     template <typename TValue, typename TResult = typename Value<typename Value<TValue, 2>::Type>::Type>
     struct _skew7NMapExtended :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
         inline TResult operator() (const TValue& x) const
         {
@@ -182,7 +181,7 @@ namespace seqan
 
     template <typename TValue, unsigned EXT_LENGTH, typename TResult = int>
     struct _skew7ExtendComp :
-        public std::binary_function<TValue, TValue, TResult>
+        std::function<TResult(TValue,TValue)>
     {
         inline TResult operator() (const TValue &a, const TValue &b) const
         {

--- a/include/seqan/index/index_skew7_multi.h
+++ b/include/seqan/index/index_skew7_multi.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_INDEX_SKEW7_MULTI_H
 #define SEQAN_HEADER_INDEX_SKEW7_MULTI_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -54,7 +56,7 @@ namespace seqan
     // *** COMPARATORS & MAPS ***
 
     template <typename TValue, typename TResult = int>
-    struct _skew7NCompMulti : public std::binary_function<TValue, TValue, TResult> {
+    struct _skew7NCompMulti : std::function<TResult(TValue,TValue)> {
         inline TResult operator() (const TValue &a, const TValue &b) const
         {
             typedef typename Value<TValue, 1>::Type                 TPos;
@@ -94,10 +96,7 @@ namespace seqan
     // optimized for bitvectors
     template <typename T1, typename TValue, typename TResult>
     struct _skew7NCompMulti< Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >, TResult > :
-        public std::binary_function<
-            Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >,
-            Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >,
-            TResult> {
+        public std::function<TResult(Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >,Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack >)> {
         inline TResult operator() (
             const Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack > &a,
             const Pair<T1, Tuple<TValue, 7, BitPacked<> >, Pack > &b) const
@@ -138,7 +137,7 @@ namespace seqan
         typename TResult = Pair<TResultSize, typename Value<TValue,2>::Type, typename Spec<TValue>::Type>
     >
     struct _skew7GlobalSlicedMulti :
-        public std::unary_function<TValue, TResult>
+        std::function<TResult(TValue)>
     {
 
         typedef TResultSize TSize;

--- a/include/seqan/index/pipe_merger7.h
+++ b/include/seqan/index/pipe_merger7.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_INDEX_MERGER7_H
 #define SEQAN_HEADER_INDEX_MERGER7_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -107,9 +109,7 @@ namespace seqan
     // greater-operator for two SkewDCStreams
     template <typename TValue>
     struct CompareSkewDCStream :
-        public std::binary_function < SkewDCStream<TValue>,
-                                        SkewDCStream<TValue>,
-                                        bool >
+        std::function<bool(SkewDCStream<TValue>,SkewDCStream<TValue>)>
     {
         inline bool operator()(const SkewDCStream<TValue> &a,
                                const SkewDCStream<TValue> &b) const
@@ -140,9 +140,7 @@ namespace seqan
     // greater-operator for two SkewDCStreams (optimized for bit-packed character tuples)
     template <typename T1, typename T2, typename T, unsigned SIZE>
     struct CompareSkewDCStream< Triple<T1, T2, Tuple<T, SIZE, BitPacked<> >, Pack> > :
-        public std::binary_function < SkewDCStream<Triple<T1, T2, Tuple<T, SIZE, BitPacked<> >, Pack> >,
-                                        SkewDCStream<Triple<T1, T2, Tuple<T, SIZE, BitPacked<> >, Pack> >,
-                                        bool >
+        std::function<bool(SkewDCStream<Triple<T1, T2, Tuple<T, SIZE, BitPacked<> >, Pack> >,SkewDCStream<Triple<T1, T2, Tuple<T, SIZE, BitPacked<> >, Pack> >)>
     {
         typedef Tuple<T,SIZE, BitPacked<> > T3;
         inline bool operator()(const SkewDCStream<Triple<T1, T2, T3, Pack> > &a,

--- a/include/seqan/index/repeat_base.h
+++ b/include/seqan/index/repeat_base.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_REPEAT_BASE_H
 #define SEQAN_HEADER_REPEAT_BASE_H
 
+#include <functional>
+
 #if SEQAN_ENABLE_PARALLELISM
 #include <seqan/parallel.h>
 #endif  // #if SEQAN_ENABLE_PARALLELISM
@@ -117,7 +119,7 @@ namespace seqan {
     }
 
     template <typename TPos>
-    struct RepeatLess_ : public std::binary_function<TPos, TPos, bool>
+    struct RepeatLess_ : std::function<bool(TPos,TPos)>
     {
         // key less
         inline bool operator() (TPos const &a, TPos const &b) const {

--- a/include/seqan/misc/set.h
+++ b/include/seqan/misc/set.h
@@ -34,6 +34,7 @@
 #define SEQAN_HEADER_MISC_SET_H
 
 #include <set>
+#include<functional>
 #include <seqan/misc/base.h>
 
 //////////////////////////////////////////////////////////////////////////////
@@ -370,7 +371,7 @@ namespace seqan
 
 
     template <typename TElement>
-    struct SetLess_ : public std::binary_function<TElement, TElement, bool>
+    struct SetLess_ : std::function<bool(TElement,TElement)>
     {
         // key less
         inline bool operator() (TElement const &a, TElement const &b) {

--- a/include/seqan/modifier/modifier_functors.h
+++ b/include/seqan/modifier/modifier_functors.h
@@ -36,6 +36,7 @@
 #define SEQAN_MODIFIER_MODIFIER_FUNCTORS_H_
 
 #include <cctype>
+#include <functional>
 
 // TODO(holtgrew): Make the structs here into classes.
 
@@ -76,7 +77,7 @@ namespace seqan
  */
 
 template <typename InType, typename Result = InType>
-struct FunctorUpcase : public std::unary_function<InType, Result>
+struct FunctorUpcase : std::function<Result(InType)>
 {
     inline Result operator()(InType x) const
     {
@@ -110,7 +111,7 @@ struct FunctorUpcase : public std::unary_function<InType, Result>
  */
 
 template <typename InType, typename Result = InType>
-struct FunctorLowcase : public std::unary_function<InType, Result>
+struct FunctorLowcase : std::function<Result(InType)>
 {
     inline Result operator()(InType x) const
     {
@@ -144,7 +145,7 @@ struct FunctorLowcase : public std::unary_function<InType, Result>
  */
 
 template <typename InType, typename OutType>
-struct FunctorConvert : public std::unary_function<InType,OutType>
+struct FunctorConvert : std::function<OutType(InType)>
 {
     inline OutType operator()(InType x) const
     {
@@ -216,7 +217,7 @@ signed char const TranslateTableIupacToIupacComplement_<T>::VALUE[16] = {0, 8, 4
  */
 
 template <>
-struct FunctorComplement<char> : public std::unary_function<Dna5,Dna5>
+struct FunctorComplement<char> : std::function<Dna5(Dna5)>
 {
     inline Dna5 operator()(Dna5 x) const
     {
@@ -225,7 +226,7 @@ struct FunctorComplement<char> : public std::unary_function<Dna5,Dna5>
 };
 
 template <>
-struct FunctorComplement<Dna> : public std::unary_function<Dna,Dna>
+struct FunctorComplement<Dna> : std::function<Dna(Dna)>
 {
     inline Dna operator()(Dna x) const
     {
@@ -234,7 +235,7 @@ struct FunctorComplement<Dna> : public std::unary_function<Dna,Dna>
 };
 
 template <>
-struct FunctorComplement<Dna5> : public std::unary_function<Dna5,Dna5>
+struct FunctorComplement<Dna5> : std::function<Dna5(Dna5)>
 {
     inline Dna5 operator()(Dna5 x) const
     {
@@ -243,7 +244,7 @@ struct FunctorComplement<Dna5> : public std::unary_function<Dna5,Dna5>
 };
 
 template <>
-struct FunctorComplement<Rna> : public std::unary_function<Rna,Rna>
+struct FunctorComplement<Rna> : std::function<Rna(Rna)>
 {
     inline Rna operator()(Rna x) const
     {
@@ -252,7 +253,7 @@ struct FunctorComplement<Rna> : public std::unary_function<Rna,Rna>
 };
 
 template <>
-struct FunctorComplement<Rna5> : public std::unary_function<Rna5,Rna5>
+struct FunctorComplement<Rna5> : std::function<Rna5(Rna5)>
 {
     inline Dna5 operator()(Rna5 x) const
     {
@@ -261,7 +262,7 @@ struct FunctorComplement<Rna5> : public std::unary_function<Rna5,Rna5>
 };
 
 template <>
-struct FunctorComplement<DnaQ> : public std::unary_function<DnaQ,DnaQ>
+struct FunctorComplement<DnaQ> : std::function<DnaQ(DnaQ)>
 {
     inline DnaQ operator()(DnaQ x) const
     {
@@ -273,7 +274,7 @@ struct FunctorComplement<DnaQ> : public std::unary_function<DnaQ,DnaQ>
 };
 
 template <>
-struct FunctorComplement<Dna5Q> : public std::unary_function<Dna5Q,Dna5Q>
+struct FunctorComplement<Dna5Q> : std::function<Dna5Q(Dna5Q)>
 {
     inline Dna5Q operator()(Dna5Q x) const {
         int qual = getQualityValue(x);
@@ -284,7 +285,7 @@ struct FunctorComplement<Dna5Q> : public std::unary_function<Dna5Q,Dna5Q>
 };
 
 template <>
-struct FunctorComplement<Iupac> : public std::unary_function<Iupac,Iupac>
+struct FunctorComplement<Iupac> : std::function<Iupac(Iupac)>
 {
     inline Iupac operator()(Iupac x) const
     {

--- a/include/seqan/modifier/modifier_position.h
+++ b/include/seqan/modifier/modifier_position.h
@@ -36,6 +36,8 @@
 #ifndef SEQAN_MODIFIER_MODIFIER_POSITION_H_
 #define SEQAN_MODIFIER_MODIFIER_POSITION_H_
 
+#include <functional>
+
 namespace seqan {
 
 // ============================================================================
@@ -390,7 +392,7 @@ inline void setPosition(ModifiedString<THost, ModPos<TPositions> > const & me, T
 // ----------------------------------------------------------------------------
 
 template <typename THost, typename TPos = typename Position<THost>::Type, typename TPredicate = std::less<TPos> >
-struct PosLess_ : public std::binary_function<TPos, TPos, bool>
+struct PosLess_ : std::function<bool(TPos, TPos)>
 {
     THost const & _host;
     TPredicate pred;

--- a/include/seqan/pipe/pipe_filter.h
+++ b/include/seqan/pipe/pipe_filter.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_PIPE_FILTER_H
 #define SEQAN_HEADER_PIPE_FILTER_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -42,7 +44,7 @@ namespace seqan
 //{
 
     template <typename TValue, typename TResult = typename Value<TValue, 1>::Type>
-    struct filterI1 : public std::unary_function<TValue, TResult>
+    struct filterI1 : std::function<TResult(TValue)>
     {
         inline TResult operator() (const TValue & x) const
         {
@@ -51,7 +53,7 @@ namespace seqan
     };
 
     template <typename TValue, typename TResult = typename Value<TValue, 2>::Type>
-    struct filterI2 : public std::unary_function<TValue, TResult>
+    struct filterI2 : std::function<TResult(TValue)>
     {
         inline TResult operator() (const TValue & x) const
         {
@@ -60,7 +62,7 @@ namespace seqan
     };
 
     template <typename TValue, typename TResult = typename Value<TValue, 3>::Type>
-    struct filterI3 : public std::unary_function<TValue, TResult>
+    struct filterI3 : std::function<TResult(TValue)>
     {
         inline TResult operator() (const TValue & x) const
         {

--- a/include/seqan/pipe/pool_mapper.h
+++ b/include/seqan/pipe/pool_mapper.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_POOL_MAPPER_H
 #define SEQAN_HEADER_POOL_MAPPER_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -348,7 +350,7 @@ namespace seqan
             cancel();
         }
 
-        struct insertBucket : public std::unary_function<TPageBucket,void>
+        struct insertBucket : std::function<void(TPageBucket)>
         {
             Handler &me;
             insertBucket(Handler &_me): me(_me) {}
@@ -454,7 +456,7 @@ namespace seqan
             cancel();
         }
 
-        struct insertBucket : public std::unary_function<TPageBucket,void>
+        struct insertBucket : std::function<void(TPageBucket)>
         {
             Handler &me;
             insertBucket(Handler &_me): me(_me) {}

--- a/include/seqan/pipe/pool_sorter.h
+++ b/include/seqan/pipe/pool_sorter.h
@@ -35,13 +35,13 @@
 #ifndef SEQAN_HEADER_POOL_SORTER_H
 #define SEQAN_HEADER_POOL_SORTER_H
 
+#include <functional>
+
 namespace seqan
 {
 
     template < typename TValue, typename Compare >
-    struct MergeStreamComparer : public std::binary_function < PageBucket<TValue>,
-                                                               PageBucket<TValue>,
-                                                               bool>
+    struct MergeStreamComparer : std::function<bool(PageBucket<TValue>,PageBucket<TValue>)>
     {
         Compare C;
         MergeStreamComparer(Compare &tmpC): C(tmpC) { }
@@ -54,10 +54,7 @@ namespace seqan
 
     template < typename TCompare >
     struct AdaptorCompare2Less :
-        public std::binary_function <
-            typename TCompare::first_argument_type,
-            typename TCompare::second_argument_type,
-            bool >
+        std::function<bool(typename TCompare::first_argument_type,typename TCompare::second_argument_type)>
     {
         TCompare const & C;
         AdaptorCompare2Less(TCompare const & tmpC): C(tmpC) { }
@@ -203,7 +200,7 @@ namespace seqan
             cancel();
         }
 
-        struct insertBucket : public std::unary_function<TPageBucket,void>
+        struct insertBucket : std::function<void(TPageBucket)>
         {
             Handler &me;
             insertBucket(Handler &_me): me(_me) {}
@@ -318,7 +315,7 @@ namespace seqan
             cancel();
         }
 
-        struct insertBucket : public std::unary_function<TPageBucket, void> {
+        struct insertBucket : std::function<void(TPageBucket)> {
             BufferHandler &me;
             insertBucket(BufferHandler &_me): me(_me) {}
 

--- a/include/seqan/seq_io/fasta_fastq.h
+++ b/include/seqan/seq_io/fasta_fastq.h
@@ -38,6 +38,8 @@
 #ifndef SEQAN_SEQ_IO_FASTA_FASTQ_H_
 #define SEQAN_SEQ_IO_FASTA_FASTQ_H_
 
+#include <functional>
+
 namespace seqan {
 
 // ============================================================================
@@ -218,7 +220,7 @@ struct SequenceOutputOptions
 // ----------------------------------------------------------------------------
 
 template <typename TValue>
-struct QualityExtractor : public std::unary_function<TValue, char>
+struct QualityExtractor : std::function<char(TValue)>
 {
     inline char operator()(TValue const & x) const
     {

--- a/include/seqan/store/store_align.h
+++ b/include/seqan/store/store_align.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_HEADER_STORE_ALIGN_H
 #define SEQAN_HEADER_STORE_ALIGN_H
 
+#include <functional>
+
 namespace seqan
 {
 
@@ -349,7 +351,7 @@ struct _LessAlignedRead;
 
 template <typename TAlignedRead>
 struct _LessAlignedRead<TAlignedRead, SortId> :
-    public std::binary_function<TAlignedRead, TAlignedRead, bool>
+    std::function<bool(TAlignedRead,TAlignedRead)>
 {
     inline bool
     operator() (TAlignedRead const& a1, TAlignedRead const& a2) const {
@@ -359,7 +361,7 @@ struct _LessAlignedRead<TAlignedRead, SortId> :
 
 template <typename TAlignedRead>
 struct _LessAlignedRead<TAlignedRead, SortContigId> :
-    public std::binary_function<TAlignedRead, TAlignedRead, bool>
+    std::function<bool(TAlignedRead,TAlignedRead)>
 {
     inline bool
     operator() (TAlignedRead const& a1, TAlignedRead const& a2) const {
@@ -369,7 +371,7 @@ struct _LessAlignedRead<TAlignedRead, SortContigId> :
 
 template <typename TAlignedRead>
 struct _LessAlignedRead<TAlignedRead, SortBeginPos> :
-    public std::binary_function<TAlignedRead, TAlignedRead, bool>
+    std::function<bool(TAlignedRead,TAlignedRead)>
 {
     inline bool
     operator() (TAlignedRead const& a1, TAlignedRead const& a2) const {
@@ -379,7 +381,7 @@ struct _LessAlignedRead<TAlignedRead, SortBeginPos> :
 
 template <typename TAlignedRead>
 struct _LessAlignedRead<TAlignedRead, SortEndPos> :
-    public std::binary_function<TAlignedRead, TAlignedRead, bool>
+    std::function<bool(TAlignedRead,TAlignedRead)>
 {
     inline bool
     operator() (TAlignedRead const& a1, TAlignedRead const& a2) const {
@@ -389,7 +391,7 @@ struct _LessAlignedRead<TAlignedRead, SortEndPos> :
 
 template <typename TAlignedRead>
 struct _LessAlignedRead<TAlignedRead, SortPairMatchId> :
-    public std::binary_function<TAlignedRead, TAlignedRead, bool>
+    std::function<bool(TAlignedRead,TAlignedRead)>
 {
     inline bool
     operator() (TAlignedRead const& a1, TAlignedRead const& a2) const {
@@ -399,7 +401,7 @@ struct _LessAlignedRead<TAlignedRead, SortPairMatchId> :
 
 template <typename TAlignedRead>
 struct _LessAlignedRead<TAlignedRead, SortReadId> :
-    public std::binary_function<TAlignedRead, TAlignedRead, bool>
+    std::function<bool(TAlignedRead,TAlignedRead)>
 {
     inline bool
     operator() (TAlignedRead const& a1, TAlignedRead const& a2) const {

--- a/include/seqan/store/store_all.h
+++ b/include/seqan/store/store_all.h
@@ -36,6 +36,7 @@
 #define SEQAN_HEADER_STORE_ALL_H
 
 //#include <stdio.h>
+#include <functional>
 
 namespace seqan
 {
@@ -2152,10 +2153,7 @@ void convertMatchesToGlobalAlignment(FragmentStore<TSpec, TConfig> &store, TScor
 
 template <typename TFragmentStore>
 struct LessConvertPairWiseToGlobalAlignment:
-    public std::binary_function<
-        typename Value<typename TFragmentStore::TAlignedReadStore>::Type,
-        typename Value<typename TFragmentStore::TAlignedReadStore>::Type,
-        bool>
+    std::function<bool(typename Value<typename TFragmentStore::TAlignedReadStore>::Type,typename Value<typename TFragmentStore::TAlignedReadStore>::Type)>
 {
     typedef typename TFragmentStore::TAlignedReadStore      TAlignedReadStore;
     typedef typename Value<TAlignedReadStore>::Type         TAlignedRead;

--- a/include/seqan/stream/stream_base.h
+++ b/include/seqan/stream/stream_base.h
@@ -199,9 +199,6 @@ guessFormatFromStream(TStream &istream, Tag<TFormat_>)
 
     SEQAN_ASSERT(istream.good());
 
-    if ((char *)MagicHeader<TFormat>::VALUE == NULL)
-        return true;
-
     bool match = true;
 
     // check magic header

--- a/src/command_line_parser.hpp
+++ b/src/command_line_parser.hpp
@@ -74,7 +74,7 @@ bool parse_command_line(options& opts, int argc, char *argv[])
     seqan::setVersion(parser, "v0.0.0");
     seqan::setUrl(parser, "https://github.com/amatria/pato");
     seqan::setShortCopyright(parser, "2022 Iñaki Amatria-Barral.");
-    seqan::setCompilationOpts(parser, "COMPILATIONOPTS_PLACEHOLDER");
+    seqan::setCompilationOpts(parser, "CXX=g++-11 CXXFLAGS=-std=c++17 -Wall -flto -O3 -march=native -s -DNDEBUG -DSEQAN_DISABLE_VERSION_CHECK -DSEQAN_ENABLE_PARALLELISM=0 LD=g++-11 LDFLAGS=-Wno-alloc-size-larger-than -flto");
 
     seqan::addSection(parser, "Input options");
     seqan::addOption(parser, seqan::ArgParseOption("ss", "single-strand-file", "File in FASTA format that is searched for TFOs (e.g. RNA or DNA).", seqan::ArgParseOption::STRING));

--- a/src/command_line_parser.hpp
+++ b/src/command_line_parser.hpp
@@ -74,7 +74,7 @@ bool parse_command_line(options& opts, int argc, char *argv[])
     seqan::setVersion(parser, "v0.0.0");
     seqan::setUrl(parser, "https://github.com/amatria/pato");
     seqan::setShortCopyright(parser, "2022 Iñaki Amatria-Barral.");
-    seqan::setCompilationOpts(parser, "CXX=g++-11 CXXFLAGS=-std=c++17 -Wall -flto -O3 -march=native -s -DNDEBUG -DSEQAN_DISABLE_VERSION_CHECK -DSEQAN_ENABLE_PARALLELISM=0 LD=g++-11 LDFLAGS=-Wno-alloc-size-larger-than -flto");
+    seqan::setCompilationOpts(parser, "CXX=g++-11 CXXFLAGS=-std=c++17 -Wall -fopenmp -flto -O3 -march=native -s -DNDEBUG -DSEQAN_DISABLE_VERSION_CHECK -DSEQAN_ENABLE_PARALLELISM=0 LD=g++-11 LDFLAGS=-Wno-alloc-size-larger-than -fopenmp -flto");
 
     seqan::addSection(parser, "Input options");
     seqan::addOption(parser, seqan::ArgParseOption("ss", "single-strand-file", "File in FASTA format that is searched for TFOs (e.g. RNA or DNA).", seqan::ArgParseOption::STRING));

--- a/src/command_line_parser.hpp
+++ b/src/command_line_parser.hpp
@@ -74,7 +74,7 @@ bool parse_command_line(options& opts, int argc, char *argv[])
     seqan::setVersion(parser, "v0.0.0");
     seqan::setUrl(parser, "https://github.com/amatria/pato");
     seqan::setShortCopyright(parser, "2022 Iñaki Amatria-Barral.");
-    seqan::setCompilationOpts(parser, "CXX=g++-11 CXXFLAGS=-std=c++17 -Wall -flto -O3 -march=native -s -DNDEBUG -DSEQAN_DISABLE_VERSION_CHECK -DSEQAN_ENABLE_PARALLELISM=0 LD=g++-11 LDFLAGS=-Wno-alloc-size-larger-than -flto");
+    seqan::setCompilationOpts(parser, "COMPILATIONOPTS_PLACEHOLDER");
 
     seqan::addSection(parser, "Input options");
     seqan::addOption(parser, seqan::ArgParseOption("ss", "single-strand-file", "File in FASTA format that is searched for TFOs (e.g. RNA or DNA).", seqan::ArgParseOption::STRING));

--- a/src/command_line_parser.hpp
+++ b/src/command_line_parser.hpp
@@ -74,7 +74,7 @@ bool parse_command_line(options& opts, int argc, char *argv[])
     seqan::setVersion(parser, "v0.0.0");
     seqan::setUrl(parser, "https://github.com/amatria/pato");
     seqan::setShortCopyright(parser, "2022 Iñaki Amatria-Barral.");
-    seqan::setCompilationOpts(parser, "CXX=g++-11 CXXFLAGS=-std=c++17 -Wall -fopenmp -flto -O3 -march=native -s -DNDEBUG -DSEQAN_DISABLE_VERSION_CHECK -DSEQAN_ENABLE_PARALLELISM=0 LD=g++-11 LDFLAGS=-Wno-alloc-size-larger-than -fopenmp -flto");
+    seqan::setCompilationOpts(parser, "CXX=g++-11 CXXFLAGS=-std=c++17 -Wall -flto -O3 -march=native -s -DNDEBUG -DSEQAN_DISABLE_VERSION_CHECK -DSEQAN_ENABLE_PARALLELISM=0 LD=g++-11 LDFLAGS=-Wno-alloc-size-larger-than -flto");
 
     seqan::addSection(parser, "Input options");
     seqan::addOption(parser, seqan::ArgParseOption("ss", "single-strand-file", "File in FASTA format that is searched for TFOs (e.g. RNA or DNA).", seqan::ArgParseOption::STRING));

--- a/src/triplex_alphabet.hpp
+++ b/src/triplex_alphabet.hpp
@@ -35,6 +35,8 @@
 #ifndef TRIPLEX_ALPHABET_HPP
 #define TRIPLEX_ALPHABET_HPP
 
+#include <functional>
+
 #include <seqan/basic.h>
 #include <seqan/modifier.h>
 #include <seqan/sequence.h>

--- a/src/triplex_alphabet.hpp
+++ b/src/triplex_alphabet.hpp
@@ -168,252 +168,6 @@ template <typename T>
 	8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8,   8  //15
 };
 
-template <typename T = void>
-struct TranslateTableDnaRY2Ascii_
-{
-	static char const VALUE[3];
-};
-template <typename T>
-	char const TranslateTableDnaRY2Ascii_<T>::VALUE[3] = {'R', 'Y', 'N'};
-
-template <typename T = void>
-struct TranslateTableDna2DnaRY_
-{
-	static char const VALUE[4];
-};
-template <typename T>
-	char const TranslateTableDna2DnaRY_<T>::VALUE[4] =
-{
-	'0', //'A'
-	'1', //'C'
-	'0', //'G'
-	'1'  //'T'
-};
-
-template <typename T = void>
-struct TranslateTableDna52DnaRY_
-{
-	static char const VALUE[5];
-};
-template <typename T>
-	char const TranslateTableDna52DnaRY_<T>::VALUE[5] =
-{
-	'0', //'A'
-	'1', //'C'
-	'0', //'G'
-	'1', //'T'
-	'2'  //'N'
-};
-
-template <typename T = void>
-struct TranslateTableIupac2DnaRY_
-{
-	static char const VALUE[16];
-};
-template <typename T>
-	char const TranslateTableIupac2DnaRY_<T>::VALUE[16] =
-{
-	1, //'U'
-	1, //'T'
-	0, //'A'
-	2, //'W' = TA
-	1, //'C'
-	1, //'Y' = TC
-	2, //'M' = AC
-	2, //'H' = not-G
-	0, //'G'
-	2, //'K' = TG
-	0, //'R' = AG
-	2, //'D' = not-C
-	2, //'S' = CG
-	2, //'B' = non-A
-	2, //'V' = non-T
-	2  //'N' = any
-};
-
-template <typename T = void>
-struct TranslateTableAscii2DnaRY_
-{
-	static char const VALUE[256];
-};
-template <typename T>
-	char const TranslateTableAscii2DnaRY_<T>::VALUE[256] =
-{
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //0
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //1
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //2
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //3
-
-	2,   0,   2,   1,   2,   2,   2,   0,   2,   2,   2,   2,   2,   2,   2,   2, //4
-//	 ,   A,   B,   C,   D,   E,   D,   G,   H,   I,   J,   K,   L,   M,   N,   O,
-
-	2,   2,   0,   2,   1,   1,   2,   2,   2,   1,   2,   2,   2,   2,   2,   2, //5
-//	P,   Q,   R,   S,   T,   U,   V,   W,   X,   Y,   Z,    ,    ,    ,    ,
-
-	2,   0,   2,   1,   2,   2,   2,   0,   2,   2,   2,   2,   2,   2,   2,   2, //6
-//   ,   a,   b,   c,   d,   e,   f,   g,   h,   i,   j,   k,   l,   m,   n,   o,
-
-	2,   2,   0,   2,   1,   1,   2,   2,   2,   1,   2,   2,   2,   2,   2,   2, //7
-//  p,   q,   r,   s,   t,   u,   v,   w,   x,   y,   z,    ,    ,    ,    ,
-
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //8
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //9
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //10
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //11
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //12
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //13
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //14
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2  //15
-};
-
-template <typename T = void>
-struct TranslateTableByte2DnaRY_
-{
-	static char const VALUE[256];
-};
-template <typename T>
-	char const TranslateTableByte2DnaRY_<T>::VALUE[256] = {
-	0,   1,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //0
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //1
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //2
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //3
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //4
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //5
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //6
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //7
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //8
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //9
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //10
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //11
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //12
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //13
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //14
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   4  //15
-};
-
-template <typename T = void>
-struct TranslateTableDnaKM2Ascii_
-{
-	static char const VALUE[3];
-};
-template <typename T>
-	char const TranslateTableDnaKM2Ascii_<T>::VALUE[3] = {'K', 'M', 'N'};
-
-template <typename T = void>
-struct TranslateTableDna2DnaKM_
-{
-	static char const VALUE[4];
-};
-template <typename T>
-	char const TranslateTableDna2DnaKM_<T>::VALUE[4] =
-{
-	'1', //'A'
-	'1', //'C'
-	'0', //'G'
-	'0'  //'T'
-};
-
-template <typename T = void>
-struct TranslateTableDna52DnaKM_
-{
-	static char const VALUE[5];
-};
-template <typename T>
-	char const TranslateTableDna52DnaKM_<T>::VALUE[5] =
-{
-	'1', //'A'
-	'1', //'C'
-	'0', //'G'
-	'0', //'T'
-	'2'  //'N'
-};
-
-template <typename T = void>
-struct TranslateTableIupac2DnaKM_
-{
-	static char const VALUE[16];
-};
-template <typename T>
-	char const TranslateTableIupac2DnaKM_<T>::VALUE[16] =
-{
-	0, //'U'
-	0, //'T'
-	1, //'A'
-	2, //'W' = TA
-	1, //'C'
-	2, //'Y' = TC
-	1, //'M' = AC
-	2, //'H' = not-G
-	0, //'G'
-	0, //'K' = TG
-	2, //'R' = AG
-	2, //'D' = not-C
-	2, //'S' = CG
-	2, //'B' = non-A
-	2, //'V' = non-T
-	2  //'N' = any
-};
-
-template <typename T = void>
-struct TranslateTableAscii2DnaKM_
-{
-	static char const VALUE[256];
-};
-template <typename T>
-	char const TranslateTableAscii2DnaKM_<T>::VALUE[256] =
-{
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //0
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //1
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //2
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //3
-
-	2,   1,   2,   1,   2,   2,   2,   0,   2,   2,   2,   0,   2,   1,   2,   2, //4
-//	 ,   A,   B,   C,   D,   E,   D,   G,   H,   I,   J,   K,   L,   M,   N,   O,
-
-	2,   2,   2,   2,   0,   0,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //5
-//	P,   Q,   R,   S,   T,   U,   V,   W,   X,   Y,   Z,    ,    ,    ,    ,
-
-	2,   1,   2,   1,   2,   2,   2,   0,   2,   2,   2,   0,   2,   1,   2,   2, //6
-//   ,   a,   b,   c,   d,   e,   f,   g,   h,   i,   j,   k,   l,   m,   n,   o,
-
-	2,   2,   2,   2,   0,   0,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //7
-//  p,   q,   r,   s,   t,   u,   v,   w,   x,   y,   z,    ,    ,    ,    ,
-
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //8
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //9
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //10
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //11
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //12
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //13
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //14
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2  //15
-};
-
-template <typename T = void>
-struct TranslateTableByte2DnaKM_
-{
-	static char const VALUE[256];
-};
-template <typename T>
-	char const TranslateTableByte2DnaKM_<T>::VALUE[256] = {
-	0,   1,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //0
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //1
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //2
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //3
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //4
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //5
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //6
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //7
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //8
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //9
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //10
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //11
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //12
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //13
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, //14
-	2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   4  //15
-};
-
 struct Triplex_ {};
 typedef SimpleType<unsigned char, Triplex_> Triplex;
 
@@ -426,46 +180,10 @@ template <> struct BitsPerValue< Triplex > {
     static const Type VALUE = 4;
 };
 
-struct DnaRY_ {};
-typedef SimpleType<unsigned char, DnaRY_> DnaRY;
-
-template <> struct ValueSize< DnaRY > { 
-	typedef uint8_t Type;
-	static const Type VALUE = 3;
-};
-template <> struct BitsPerValue< DnaRY > { 
-	typedef uint8_t Type;
-    static const Type VALUE = 2;
-};
-
-struct DnaKM_ {};
-typedef SimpleType<unsigned char, DnaKM_> DnaKM;
-
-template <> struct ValueSize< DnaKM > { 
-	typedef uint8_t Type;
-	static const Type VALUE = 3;
-};
-template <> struct BitsPerValue< DnaKM > { 
-	typedef uint8_t Type;
-    static const Type VALUE = 2;
-};
-
 inline void assign(Ascii & c_target,
 				   Triplex const & source)
 {
 	c_target = TranslateTableTriplex2Ascii_<>::VALUE[source.value];
-}
-
-inline void assign(Ascii & c_target,
-				   DnaRY const & source)
-{
-	c_target = TranslateTableDnaRY2Ascii_<>::VALUE[source.value];
-}
-
-inline void assign(Ascii & c_target,
-				   DnaKM const & source)
-{
-	c_target = TranslateTableDnaKM2Ascii_<>::VALUE[source.value];
 }
 
 template <>
@@ -510,90 +228,6 @@ inline void assign(Triplex & target, Iupac const & source)
 	target.value = TranslateTableIupac2Triplex_<>::VALUE[source.value];
 }
 
-template <>
-struct CompareType<DnaRY, uint8_t> { typedef DnaRY Type; };
-inline void assign(DnaRY & target, uint8_t c_source)
-{
-	target.value = TranslateTableByte2DnaRY_<>::VALUE[c_source];
-}
-
-template <>
-struct CompareType<DnaRY, Ascii> { typedef DnaRY Type; };
-inline void assign(DnaRY & target, Ascii c_source)
-{
-	target.value = TranslateTableAscii2DnaRY_<>::VALUE[(unsigned char)c_source];
-}
-
-template <>
-struct CompareType<DnaRY, Unicode> { typedef DnaRY Type; };
-inline void assign(DnaRY & target, Unicode c_source)
-{
-	target.value = TranslateTableAscii2DnaRY_<>::VALUE[(unsigned char) c_source];
-}
-
-template <>
-struct CompareType<DnaRY, Dna> { typedef DnaRY Type; };
-inline void assign(DnaRY & target, Dna const & c_source)
-{
-	target.value = TranslateTableDna2DnaRY_<>::VALUE[(unsigned char) c_source];
-}
-
-template <>
-struct CompareType<DnaRY, Dna5> { typedef DnaRY Type; };
-inline void assign(DnaRY & target, Dna5 const & c_source)
-{
-	target.value = TranslateTableDna52DnaRY_<>::VALUE[(unsigned char) c_source];
-}
-
-template <>
-struct CompareType<DnaRY, Iupac> { typedef DnaRY Type; };
-inline void assign(DnaRY & target, Iupac const & source)
-{
-	target.value = TranslateTableIupac2DnaRY_<>::VALUE[source.value];
-}
-
-template <>
-struct CompareType<DnaKM, uint8_t> { typedef DnaKM Type; };
-inline void assign(DnaKM & target, uint8_t c_source)
-{
-	target.value = TranslateTableByte2DnaKM_<>::VALUE[c_source];
-}
-
-template <>
-struct CompareType<DnaKM, Ascii> { typedef DnaKM Type; };
-inline void assign(DnaKM & target, Ascii c_source)
-{
-	target.value = TranslateTableAscii2DnaKM_<>::VALUE[(unsigned char)c_source];
-}
-
-template <>
-struct CompareType<DnaKM, Unicode> { typedef DnaKM Type; };
-inline void assign(DnaKM & target, Unicode c_source)
-{
-	target.value = TranslateTableAscii2DnaKM_<>::VALUE[(unsigned char) c_source];
-}
-
-template <>
-struct CompareType<DnaKM, Dna> { typedef DnaKM Type; };
-inline void assign(DnaKM & target, Dna const & c_source)
-{
-	target.value = TranslateTableDna2DnaKM_<>::VALUE[(unsigned char) c_source];
-}
-
-template <>
-struct CompareType<DnaKM, Dna5> { typedef DnaKM Type; };
-inline void assign(DnaKM & target, Dna5 const & c_source)
-{
-	target.value = TranslateTableDna52DnaKM_<>::VALUE[(unsigned char) c_source];
-}
-
-template <>
-struct CompareType<DnaKM, Iupac> { typedef DnaKM Type; };
-inline void assign(DnaKM & target, Iupac const & source)
-{
-	target.value = TranslateTableIupac2DnaKM_<>::VALUE[source.value];
-}
-
 template <typename T = void>
 struct TranslateTableTriplex2TriplexComplement_
 {
@@ -601,22 +235,6 @@ struct TranslateTableTriplex2TriplexComplement_
 };
 template <typename T>
 	char const TranslateTableTriplex2TriplexComplement_<T>::VALUE[9] = {'T', 'G', 'C', 'A', 'Y', 'R', 'M', 'K'};
-
-template <typename T = void>
-struct TranslateTableDnaRY2DnaRYComplement_
-{
-	static char const VALUE[3];
-};
-template <typename T>
-	char const TranslateTableDnaRY2DnaRYComplement_<T>::VALUE[3] = {'Y', 'R', 'N'};
-
-template <typename T = void>
-struct TranslateTableDnaKM2DnaKMComplement_
-{
-	static char const VALUE[3];
-};
-template <typename T>
-	char const TranslateTableDnaKM2DnaKMComplement_<T>::VALUE[3] = {'M', 'K', 'N'};
 
 inline bool isMatch(Triplex val1, Triplex val2)
 {
@@ -627,7 +245,7 @@ inline bool isMatch(Triplex val1, Triplex val2)
 	else 
 		return false;
 }
-	
+
 template <typename TAlphabet>
 inline bool isMatch(TAlphabet val1, TAlphabet val2)
 {
@@ -642,64 +260,22 @@ inline bool _repeatMaskValue(Triplex const &val)
 	return val == unknownValue<Triplex>(); // 'N'
 }
 
-inline bool _repeatMaskValue(DnaRY const &val)
-{
-	return val == unknownValue<DnaRY>(); // 'N'
-}
-
-inline bool _repeatMaskValue(DnaKM const &val)
-{
-	return val == unknownValue<DnaKM>(); // 'N'
-}
-
 typedef String<Triplex, Alloc<void> > TriplexString;
-typedef String<DnaRY, Alloc<void> > DnaRYString;
-typedef String<DnaKM, Alloc<void> > DnaKMString;
 
 typedef ModView< FunctorComplement<Triplex> >	ModComplementTriplex;
-typedef ModView< FunctorComplement<DnaRY> >	ModComplementDnaRY;
-typedef ModView< FunctorComplement<DnaKM> >	ModComplementDnaKM;
 
 typedef ModifiedString<TriplexString, ModView< FunctorComplement<Triplex> > >		TriplexStringComplement;
-typedef ModifiedString<DnaRYString, ModView< FunctorComplement<DnaRY> > >		DnaRYStringComplement;
-typedef ModifiedString<DnaKMString, ModView< FunctorComplement<DnaKM> > >		DnaKMStringComplement;
 
 typedef ModifiedString<
 			ModifiedString<	TriplexString, ModView< FunctorComplement<Triplex> > >,
 			ModReverse
 		>	TriplexStringReverseComplement;
 
-typedef ModifiedString<
-			ModifiedString<	DnaRYString, ModView< FunctorComplement<DnaRY> > >,
-			ModReverse
-		>	DnaRYStringReverseComplement;
-
-typedef ModifiedString<
-			ModifiedString<	DnaKMString, ModView< FunctorComplement<DnaKM> > >,
-			ModReverse
-		>	DnaKMStringReverseComplement;
-
 template <>
-struct FunctorComplement<Triplex> : public ::std::unary_function<Triplex,Triplex>
+struct FunctorComplement<Triplex> : std::function<Triplex(Triplex)>
 {
-    inline Triplex operator()(Triplex x) const {
+	inline Triplex operator()(Triplex x) const {
 		return TranslateTableTriplex2TriplexComplement_<>::VALUE[x.value];
-	}
-};
-
-template <>
-struct FunctorComplement<DnaRY> : public ::std::unary_function<DnaRY,DnaRY>
-{
-    inline DnaRY operator()(DnaRY x) const {
-		return TranslateTableDnaRY2DnaRYComplement_<>::VALUE[x.value];
-	}
-};
-
-template <>
-struct FunctorComplement<DnaKM> : public ::std::unary_function<DnaKM,DnaKM>
-{
-    inline DnaKM operator()(DnaKM x) const {
-		return TranslateTableDnaKM2DnaKMComplement_<>::VALUE[x.value];
 	}
 };
 

--- a/src/triplex_functors.hpp
+++ b/src/triplex_functors.hpp
@@ -43,82 +43,13 @@ namespace seqan
 /**
  * mask all purines (G,A) in a sequences with 'R' and pyrimidins (C,T/U) as 'Y'
  */
-auto FunctorRYFilter = [](Triplex x) -> Triplex {
-	if ((x == 'G') || (x == 'g') || (x == 'A') || (x == 'a') || (x == 'R'))
-		return 'R';
-	else if ((x == 'C') || (x == 'c') || (x == 'T') || (x == 't') || (x == 'U') || (x == 'u') || (x == 'Y'))
-		return 'Y';
-	else
-		return 'N';
-};
-
-/**
- * mask all pyrimidins (C,T/U) as 'Y'
- */
-struct FunctorGAYFilter : public ::std::unary_function<Triplex,Triplex>
+struct FunctorRYFilter : public std::function<Triplex(Triplex)>
 {
 	inline Triplex operator()(Triplex x) const {
-		if ((x == 'G') || (x == 'g'))
-			return 'G';
-		else if ((x == 'A') || (x == 'a'))
-			return 'A';
-		else if (x == 'R')
+		if ((x == 'G') || (x == 'g') || (x == 'A') || (x == 'a') || (x == 'R'))
 			return 'R';
 		else if ((x == 'C') || (x == 'c') || (x == 'T') || (x == 't') || (x == 'U') || (x == 'u') || (x == 'Y'))
 			return 'Y';
-		else
-			return 'N';
-	}
-};
-
-/**
- * mask all purines (G,A) in a sequences with 'R'
- */
-struct FunctorCTRFilter : public ::std::unary_function<Triplex,Triplex>
-{
-	inline Triplex operator()(Triplex x) const {
-		if ((x == 'C') || (x == 'c'))
-			return 'C';
-		else if ((x == 'T') || (x == 't') || (x == 'U') || (x == 'u'))
-			return 'T';
-		else if (x == 'Y')
-			return 'Y';
-		else if ((x == 'G') || (x == 'g') || (x == 'A') || (x == 'a') || (x == 'R'))
-			return 'R';
-		else
-			return 'N';
-	}
-};
-
-/**
- * mask all (C,A) in a sequences with 'M'
- */
-struct FunctorGTMFilter : public ::std::unary_function<Triplex,Triplex>
-{
-	inline Triplex operator()(Triplex x) const {
-		if ((x == 'G') || (x == 'g'))
-			return 'G';
-		else if ((x == 'T') || (x == 't') || (x == 'U') || (x == 'u'))
-			return 'T';
-		else if (x == 'K')
-			return 'K';
-		else if ((x == 'C') || (x == 'c') || (x == 'A') || (x == 'a') || (x == 'M'))
-			return 'M';
-		else
-			return 'N';
-	}
-};
-
-/**
- * mask all (T/U,G) in a sequences with 'K' and all (A,C) with 'M'. Covers both DNA and RNA.
- */
-struct FunctorKMFilter : public ::std::unary_function<Triplex,Triplex>
-{
-	inline Triplex operator()(Triplex x) const {
-		if ((x == 'C') || (x == 'c') || (x == 'A') || (x == 'a') || (x == 'M'))
-			return 'M';
-		else if ((x == 'G') || (x == 'g') || (x == 'T') || (x == 't') || (x == 'U') || (x == 'u') || (x == 'K'))
-			return 'K';
 		else
 			return 'N';
 	}

--- a/src/triplex_functors.hpp
+++ b/src/triplex_functors.hpp
@@ -43,16 +43,13 @@ namespace seqan
 /**
  * mask all purines (G,A) in a sequences with 'R' and pyrimidins (C,T/U) as 'Y'
  */
-struct FunctorRYFilter : public ::std::unary_function<Triplex,Triplex>
-{
-	inline Triplex operator()(Triplex x) const {
-		if ((x == 'G') || (x == 'g') || (x == 'A') || (x == 'a') || (x == 'R'))
-			return 'R';
-		else if ((x == 'C') || (x == 'c') || (x == 'T') || (x == 't') || (x == 'U') || (x == 'u') || (x == 'Y'))
-			return 'Y';
-		else
-			return 'N';
-	}
+auto FunctorRYFilter = [](Triplex x) -> Triplex {
+	if ((x == 'G') || (x == 'g') || (x == 'A') || (x == 'a') || (x == 'R'))
+		return 'R';
+	else if ((x == 'C') || (x == 'c') || (x == 'T') || (x == 't') || (x == 'U') || (x == 'u') || (x == 'Y'))
+		return 'Y';
+	else
+		return 'N';
 };
 
 /**

--- a/src/triplex_functors.hpp
+++ b/src/triplex_functors.hpp
@@ -35,6 +35,8 @@
 #ifndef TRIPLEX_FUNCTORS_HPP
 #define TRIPLEX_FUNCTORS_HPP
 
+#include <functional>
+
 #include "triplex_alphabet.hpp"
 
 namespace seqan
@@ -43,7 +45,7 @@ namespace seqan
 /**
  * mask all purines (G,A) in a sequences with 'R' and pyrimidins (C,T/U) as 'Y'
  */
-struct FunctorRYFilter : public std::function<Triplex(Triplex)>
+struct FunctorRYFilter : std::function<Triplex(Triplex)>
 {
 	inline Triplex operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g') || (x == 'A') || (x == 'a') || (x == 'R'))
@@ -59,7 +61,7 @@ struct FunctorRYFilter : public std::function<Triplex(Triplex)>
  * Translate the TC motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorTCMotif : public ::std::unary_function<Triplex,Triplex>
+struct FunctorTCMotif : std::function<Triplex(Triplex)>
 {
 	inline Triplex operator()(Triplex x) const {
 		if ((x == 'C') || (x == 'c') )
@@ -75,7 +77,7 @@ struct FunctorTCMotif : public ::std::unary_function<Triplex,Triplex>
  * Translate the TC motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorGAMotif : public ::std::unary_function<Triplex,Triplex>
+struct FunctorGAMotif : std::function<Triplex(Triplex)>
 {
 	inline Triplex operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g'))
@@ -91,7 +93,7 @@ struct FunctorGAMotif : public ::std::unary_function<Triplex,Triplex>
  * Translate the GT motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorGTMotif : public ::std::unary_function<Triplex,Triplex>
+struct FunctorGTMotif : std::function<Triplex(Triplex)>
 {
 	inline Triplex operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g') )
@@ -107,7 +109,7 @@ struct FunctorGTMotif : public ::std::unary_function<Triplex,Triplex>
  * Translate the TC motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorTCMotifPretty : public ::std::unary_function<Triplex,char>
+struct FunctorTCMotifPretty : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'C') || (x == 'c') )
@@ -127,7 +129,7 @@ struct FunctorTCMotifPretty : public ::std::unary_function<Triplex,char>
  * Translate the TC motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorGAMotifPretty : public ::std::unary_function<Triplex,char>
+struct FunctorGAMotifPretty : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g'))
@@ -147,7 +149,7 @@ struct FunctorGAMotifPretty : public ::std::unary_function<Triplex,char>
  * Translate the GT motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorGTMotifPretty : public ::std::unary_function<Triplex,char>
+struct FunctorGTMotifPretty : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g') )
@@ -167,7 +169,7 @@ struct FunctorGTMotifPretty : public ::std::unary_function<Triplex,char>
  * Translate the TC motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorTCMotifOutput : public ::std::unary_function<Triplex,char>
+struct FunctorTCMotifOutput : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'C') || (x == 'c') )
@@ -187,7 +189,7 @@ struct FunctorTCMotifOutput : public ::std::unary_function<Triplex,char>
  * Translate the TC motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorGAMotifOutput : public ::std::unary_function<Triplex,char>
+struct FunctorGAMotifOutput : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g'))
@@ -207,7 +209,7 @@ struct FunctorGAMotifOutput : public ::std::unary_function<Triplex,char>
  * Translate the GT motif into a corresponding triplex target site and mask all remaining
  * character with 'N'
  */
-struct FunctorGTMotifOutput : public ::std::unary_function<Triplex,char>
+struct FunctorGTMotifOutput : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g') )
@@ -227,7 +229,7 @@ struct FunctorGTMotifOutput : public ::std::unary_function<Triplex,char>
  * Masks non-purine characters of a putative triplex target site 
  * with 'Y' (Different character than masking for TFOs!)
  */
-struct FunctorTTSMotif : public ::std::unary_function<Triplex,Triplex>
+struct FunctorTTSMotif : std::function<Triplex(Triplex)>
 {
 	inline Triplex operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g'))
@@ -243,7 +245,7 @@ struct FunctorTTSMotif : public ::std::unary_function<Triplex,Triplex>
  * Masks non-purine characters of a putative triplex target site 
  * with 'Y' (Different character than masking for TFOs!)
  */
-struct FunctorTTSMotifPretty : public ::std::unary_function<Triplex,char>
+struct FunctorTTSMotifPretty : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g'))
@@ -263,7 +265,7 @@ struct FunctorTTSMotifPretty : public ::std::unary_function<Triplex,char>
  * Masks non-purine characters of a putative triplex target site 
  * with 'Y' (Different character than masking for TFOs!)
  */
-struct FunctorTTSMotifOutput : public ::std::unary_function<Triplex,char>
+struct FunctorTTSMotifOutput : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'G') || (x == 'g'))
@@ -283,7 +285,7 @@ struct FunctorTTSMotifOutput : public ::std::unary_function<Triplex,char>
  * Masks non-pyrimidine characters of a putative triplex target site 
  * with 'Y' (Different character than masking for TFOs!)
  */
-struct FunctorTTSMotifCompl : public ::std::unary_function<Triplex,Triplex>
+struct FunctorTTSMotifCompl : std::function<Triplex(Triplex)>
 {
 	inline Triplex operator()(Triplex x) const {
 		if ((x == 'C') || (x == 'c'))
@@ -299,7 +301,7 @@ struct FunctorTTSMotifCompl : public ::std::unary_function<Triplex,Triplex>
  * Masks non-pyrimidine characters of a putative triplex target site 
  * with 'Y' (Different character than masking for TFOs!)
  */
-struct FunctorTTSMotifComplPretty : public ::std::unary_function<Triplex,char>
+struct FunctorTTSMotifComplPretty : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'C') || (x == 'c'))
@@ -319,7 +321,7 @@ struct FunctorTTSMotifComplPretty : public ::std::unary_function<Triplex,char>
  * Masks non-pyrimidine characters of a putative triplex target site 
  * with 'Y' (Different character than masking for TFOs!)
  */
-struct FunctorTTSMotifComplOutput : public ::std::unary_function<Triplex,char>
+struct FunctorTTSMotifComplOutput : std::function<char(Triplex)>
 {
 	inline char operator()(Triplex x) const {
 		if ((x == 'C') || (x == 'c'))


### PR DESCRIPTION
Remove deprecation warnings when compiling with GCCv12.
Remove unreachable statement in `guessFormatFromFileStream`.
Remove dead code.